### PR TITLE
Update for CUDA 10

### DIFF
--- a/README
+++ b/README
@@ -5,3 +5,7 @@ Corresponds to Video Codec SDK version 8.2.25.
 Minimum required driver versions:
 Linux: 396.24 or newer
 Windows: 397.93 or newer
+
+Optional CUDA 10 features:
+Linux: 410.48 or newer
+Windows: 411.31 or newer

--- a/ffnvcodec.pc.in
+++ b/ffnvcodec.pc.in
@@ -3,5 +3,5 @@ includedir=${prefix}/include
 
 Name: ffnvcodec
 Description: FFmpeg version of Nvidia Codec SDK headers
-Version: 8.2.15.0
+Version: 8.2.15.1
 Cflags: -I${includedir}

--- a/include/ffnvcodec/dynlink_loader.h
+++ b/include/ffnvcodec/dynlink_loader.h
@@ -171,6 +171,13 @@ typedef struct CudaFunctions {
     tcuGraphicsUnmapResources *cuGraphicsUnmapResources;
     tcuGraphicsSubResourceGetMappedArray *cuGraphicsSubResourceGetMappedArray;
 
+    tcuImportExternalMemory *cuImportExternalMemory;
+    tcuDestroyExternalMemory *cuDestroyExternalMemory;
+    tcuExternalMemoryGetMappedBuffer *cuExternalMemoryGetMappedBuffer;
+    tcuExternalMemoryGetMappedMipmappedArray *cuExternalMemoryGetMappedMipmappedArray;
+
+    tcuMipmappedArrayGetLevel *cuMipmappedArrayGetLevel;
+
     FFNV_LIB_HANDLE lib;
 } CudaFunctions;
 #else
@@ -271,6 +278,12 @@ static inline int cuda_load_functions(CudaFunctions **functions, void *logctx)
     LOAD_SYMBOL(cuGraphicsMapResources, tcuGraphicsMapResources, "cuGraphicsMapResources");
     LOAD_SYMBOL(cuGraphicsUnmapResources, tcuGraphicsUnmapResources, "cuGraphicsUnmapResources");
     LOAD_SYMBOL(cuGraphicsSubResourceGetMappedArray, tcuGraphicsSubResourceGetMappedArray, "cuGraphicsSubResourceGetMappedArray");
+
+    LOAD_SYMBOL_OPT(cuImportExternalMemory, tcuImportExternalMemory, "cuImportExternalMemory");
+    LOAD_SYMBOL_OPT(cuDestroyExternalMemory, tcuDestroyExternalMemory, "cuDestroyExternalMemory");
+    LOAD_SYMBOL_OPT(cuExternalMemoryGetMappedBuffer, tcuExternalMemoryGetMappedBuffer, "cuExternalMemoryGetMappedBuffer");
+    LOAD_SYMBOL_OPT(cuExternalMemoryGetMappedMipmappedArray, tcuExternalMemoryGetMappedMipmappedArray, "cuExternalMemoryGetMappedMipmappedArray");
+    LOAD_SYMBOL_OPT(cuMipmappedArrayGetLevel, tcuMipmappedArrayGetLevel, "cuMipmappedArrayGetLevel");
 
     GENERIC_LOAD_FUNC_FINALE(cuda);
 }


### PR DESCRIPTION
This adds support for the CUDA/Vulkan interop API, which requires
very new driver versions.

The new version requirements are pretty extreme, but there's no way around it if you want the interop API.