### PR TITLE
Add basic Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+dist: xenial
+
+compiler:
+  - clang
+  - gcc
+
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ compiler:
   - clang
   - gcc
 
+install: make install
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: c
 dist: xenial
 
-compiler:
-  - clang
-  - gcc
-
-install: make install
 script: make
+
+jobs:
+  include:
+    - name: "Linux GCC"
+    - name: "Linux Clang"
+      compiler: clang
+    - name: "macOS GCC"
+      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: c
 dist: xenial
 
-script: make
+script:
+ - make
+ - make install
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 
 script:
  - make
- - make install
+ - sudo make install
 
 jobs:
   include:


### PR DESCRIPTION
Tests the Makefile with `make` and `make install` on Ubuntu 16.04 and macOS with GCC and Clang.

For optimal integration with GitHub Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) on the GitHub Marketplace.