### PR TITLE
Fix Issue where functions have been removed the API for OSX in dynlink_nvcuvid.h but are still being processed in dynlink_loader.h

### DIFF
--- a/include/ffnvcodec/dynlink_loader.h
+++ b/include/ffnvcodec/dynlink_loader.h
@@ -215,6 +215,7 @@ typedef struct CuvidFunctions {
     tcuvidCtxLock *cuvidCtxLock;
     tcuvidCtxUnlock *cuvidCtxUnlock;
 
+#if !defined(__APPLE__)
     tcuvidCreateVideoSource *cuvidCreateVideoSource;
     tcuvidCreateVideoSourceW *cuvidCreateVideoSourceW;
     tcuvidDestroyVideoSource *cuvidDestroyVideoSource;
@@ -222,6 +223,7 @@ typedef struct CuvidFunctions {
     tcuvidGetVideoSourceState *cuvidGetVideoSourceState;
     tcuvidGetSourceVideoFormat *cuvidGetSourceVideoFormat;
     tcuvidGetSourceAudioFormat *cuvidGetSourceAudioFormat;
+#endif
     tcuvidCreateVideoParser *cuvidCreateVideoParser;
     tcuvidParseVideoData *cuvidParseVideoData;
     tcuvidDestroyVideoParser *cuvidDestroyVideoParser;
@@ -345,6 +347,7 @@ static inline int cuvid_load_functions(CuvidFunctions **functions, void *logctx)
     LOAD_SYMBOL(cuvidCtxLock, tcuvidCtxLock, "cuvidCtxLock");
     LOAD_SYMBOL(cuvidCtxUnlock, tcuvidCtxUnlock, "cuvidCtxUnlock");
 
+#if !defined(__APPLE__)
     LOAD_SYMBOL(cuvidCreateVideoSource, tcuvidCreateVideoSource, "cuvidCreateVideoSource");
     LOAD_SYMBOL(cuvidCreateVideoSourceW, tcuvidCreateVideoSourceW, "cuvidCreateVideoSourceW");
     LOAD_SYMBOL(cuvidDestroyVideoSource, tcuvidDestroyVideoSource, "cuvidDestroyVideoSource");
@@ -352,6 +355,7 @@ static inline int cuvid_load_functions(CuvidFunctions **functions, void *logctx)
     LOAD_SYMBOL(cuvidGetVideoSourceState, tcuvidGetVideoSourceState, "cuvidGetVideoSourceState");
     LOAD_SYMBOL(cuvidGetSourceVideoFormat, tcuvidGetSourceVideoFormat, "cuvidGetSourceVideoFormat");
     LOAD_SYMBOL(cuvidGetSourceAudioFormat, tcuvidGetSourceAudioFormat, "cuvidGetSourceAudioFormat");
+#endif
     LOAD_SYMBOL(cuvidCreateVideoParser, tcuvidCreateVideoParser, "cuvidCreateVideoParser");
     LOAD_SYMBOL(cuvidParseVideoData, tcuvidParseVideoData, "cuvidParseVideoData");
     LOAD_SYMBOL(cuvidDestroyVideoParser, tcuvidDestroyVideoParser, "cuvidDestroyVideoParser");


### PR DESCRIPTION
Do not try and dyn link CUVID functions not available for OSX and have already been eliminated in dynlink_nvcuvid.h with a conditional build directive. Fixes build issues for OSX.